### PR TITLE
Remove default features for plugin users

### DIFF
--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -10,7 +10,7 @@ description = "A toolset that allows you to debug / view any bevy application wi
 crate-type=["dylib"]
 
 [dependencies]
-bevy = { version = "0.6", features = ["trace","bevy_render", "bevy_pbr", "dynamic"] }
+bevy = { version = "0.6", default-features = false, features = ["trace","bevy_render", "bevy_pbr", "dynamic"] }
 json = "0.12.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This reduces the dependencies that plugin users need to pull in when using the plugin. This is recommended best practice for plugin authors. ❤️ 