### PR TITLE
Remove bevy dynamic feature

### DIFF
--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -10,7 +10,7 @@ description = "A toolset that allows you to debug / view any bevy application wi
 crate-type=["dylib"]
 
 [dependencies]
-bevy = { version = "0.6", features = ["trace","bevy_render", "bevy_pbr", "dynamic"] }
+bevy = { version = "0.6", features = ["trace","bevy_render", "bevy_pbr"] }
 json = "0.12.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This prevents users from being forced to use the dynamic feature in downstream projects. People who want to use dynamic can just pass in the flag `--features bevy/dynamic`, or put the dynamic feature in their project that uses this plugin.